### PR TITLE
Fix for uninitialized "root" variable

### DIFF
--- a/docs/configuration/secure.md
+++ b/docs/configuration/secure.md
@@ -610,8 +610,8 @@ This is a NGINX recommended configuration. (note: inside the `%DOCROOT%/data` no
 ```
     server {
         [...]
+        set $root $document_root;
         location ~ /data/ {
-            set $root $document_root;
             rewrite ^/data/(.*)/(.*)/(.*)$ /Services/WebAccessChecker/wac.php last;
 
             location ~ [^/]\.php(/|$) { access_log off; log_not_found off; deny all; }


### PR DESCRIPTION
This entry appears in the error log while testing rewrite rules:  ```using uninitialized "root" variable```.
The $root variable declared in the previous location is apparently out of scope here and would probably be better declared in the server scope.