### PR TITLE
ECS: Enable HTTP when DEVMODE is set

### DIFF
--- a/components/ILIAS/WebServices/ECS/classes/class.ilECSSettingsGUI.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilECSSettingsGUI.php
@@ -302,10 +302,15 @@ class ilECSSettingsGUI
         $this->form->addItem($ser);
 
         $pro = new ilSelectInputGUI($this->lng->txt('ecs_protocol'), 'protocol');
-        $pro->setOptions(array(
-            ilECSSetting::PROTOCOL_HTTPS => 'HTTPS',
-            ilECSSetting::PROTOCOL_HTTP => 'HTTP'
-        ));
+        $pro_options = (defined('DEVMODE') && DEVMODE)
+            ? [
+                ilECSSetting::PROTOCOL_HTTPS => 'HTTPS',
+                ilECSSetting::PROTOCOL_HTTP  => 'HTTP',
+            ]
+            : [
+                ilECSSetting::PROTOCOL_HTTPS => 'HTTPS',
+            ];
+        $pro->setOptions($pro_options);
         $pro->setValue($this->settings->getProtocol());
         $pro->setRequired(true);
         $this->form->addItem($pro);


### PR DESCRIPTION
Instead of allowing HTTP in general, only allow it when DEVMODE is set for that instance. 

In a production environment, HTTPS should always be used. In my opinion, this option should not be available in this case.

